### PR TITLE
Fix Getter.get type annotations

### DIFF
--- a/tests/test_getter_annotations.py
+++ b/tests/test_getter_annotations.py
@@ -1,0 +1,17 @@
+import unittest
+from typing import Union, get_type_hints
+
+from zabbix_utils.getter import Getter
+from zabbix_utils.types import AgentResponse
+
+
+class TestGetterAnnotations(unittest.TestCase):
+    def test_get_annotations_match_supported_payloads_and_response(self):
+        hints = get_type_hints(Getter.get)
+
+        self.assertEqual(hints["key"], Union[bytes, str, list, dict])
+        self.assertIs(hints["return"], AgentResponse)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/zabbix_utils/getter.py
+++ b/zabbix_utils/getter.py
@@ -9,10 +9,10 @@
 # merge, publish, distribute, sublicense, and/or sell copies
 # of the Software, and to permit persons to whom the Software
 # is furnished to do so, subject to the following conditions:
-
+#
 # The above copyright notice and this permission notice shall be
 # included in all copies or substantial portions of the Software.
-
+#
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 # EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
 # OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -73,14 +73,14 @@ class Getter():
 
         return result
 
-    def get(self, key: str) -> Union[str, None]:
+    def get(self, key: Union[bytes, str, list, dict]) -> AgentResponse:
         """Gets item value from Zabbix agent by specified key.
 
         Args:
-            key (str): Zabbix item key.
+            key (bytes|str|list|dict): Zabbix item key or protocol payload.
 
         Returns:
-            str: Value from Zabbix agent for specified key.
+            AgentResponse: Response from the Zabbix agent.
         """
 
         packet = ZabbixProtocol.create_packet(key, log)


### PR DESCRIPTION
## Summary

- update `Getter.get()` input typing to match the payload types accepted by `ZabbixProtocol.create_packet()`
- update the return annotation to `AgentResponse`
- correct the method documentation
- add focused regression coverage for the public annotations

## Validation

- `python -m unittest tests.test_getter_annotations`
- changed Python files compile successfully
- no runtime behavior changes

Fixes #39